### PR TITLE
The Polysub engine has moved from we to norns core. Fixes #7

### DIFF
--- a/fretwork.lua
+++ b/fretwork.lua
@@ -4,8 +4,8 @@
 -- microtonal autoharp,
 -- etc.
 
+polysub = require 'polysub'
 engine.name = 'PolySub'
-polysub = require 'we/lib/polysub'
 
 musicutil = require 'musicutil'
 


### PR DESCRIPTION
Just a little fix to get the Polysub from norns core rather than the now deprecated *we* library. Works for me.

Thanks for nice script :)